### PR TITLE
Correct math for scaling factor

### DIFF
--- a/tf_glove.py
+++ b/tf_glove.py
@@ -13,7 +13,7 @@ class NotFitToCorpusError(Exception):
 
 class GloVeModel():
     def __init__(self, embedding_size, context_size, max_vocab_size=100000, min_occurrences=1,
-                 scaling_factor=3/4, cooccurrence_cap=100, batch_size=512, learning_rate=0.05):
+                 scaling_factor=3.0/4.0, cooccurrence_cap=100, batch_size=512, learning_rate=0.05):
         self.embedding_size = embedding_size
         if isinstance(context_size, tuple):
             self.left_context, self.right_context = context_size


### PR DESCRIPTION
Scaling factor was defaulting to zero due to integer division.  However, it seems that the default was meant to be .75.  If not, please disregard.
