### PR TITLE
Revert "Correct math for scaling factor"

### DIFF
--- a/tf_glove.py
+++ b/tf_glove.py
@@ -13,7 +13,7 @@ class NotFitToCorpusError(Exception):
 
 class GloVeModel():
     def __init__(self, embedding_size, context_size, max_vocab_size=100000, min_occurrences=1,
-                 scaling_factor=3.0/4.0, cooccurrence_cap=100, batch_size=512, learning_rate=0.05):
+                 scaling_factor=3/4, cooccurrence_cap=100, batch_size=512, learning_rate=0.05):
         self.embedding_size = embedding_size
         if isinstance(context_size, tuple):
             self.left_context, self.right_context = context_size


### PR DESCRIPTION
This reverts commit b319ba189e75a06d062162e296a41bf1b6b46d02.
`3 / 4` should work even on Python 2 because importing `division` from `__future__`.

```
$ python2
Python 2.7.12 (default, Nov 17 2016, 00:43:43)
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> 3 / 4
0
>>> from __future__ import division
>>> 3 / 4
0.75
>>>
```